### PR TITLE
PYI-564 - Add dockerfile for sam cli

### DIFF
--- a/.github/workflows/build_aws_sam.yml
+++ b/.github/workflows/build_aws_sam.yml
@@ -1,0 +1,27 @@
+name: di-aws-sam
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'aws-sam/**'
+
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Tag used within docker repository to mark as unique"
+        required: false
+        type: string
+
+jobs:
+  build-and-push:
+    uses: alphagov/di-dockerfiles/.github/workflows/publish_to_ghcr.yml@master
+    with:
+      docker_context: ./aws-sam
+      push_to_ghcr: true
+      ghcr_repo: ghcr.io/alphagov/aws-sam
+      image_tag: ${{ github.event.inputs.image_tag }}
+    secrets:
+      ghcr_username: ${{ secrets.GHCR_USERNAME }}
+      ghcr_token: ${{ secrets.CHCR_TOKEN }}

--- a/.github/workflows/build_aws_sam.yml
+++ b/.github/workflows/build_aws_sam.yml
@@ -22,6 +22,4 @@ jobs:
       push_to_ghcr: true
       ghcr_repo: ghcr.io/alphagov/aws-sam
       image_tag: ${{ github.event.inputs.image_tag }}
-    secrets:
-      ghcr_username: ${{ secrets.GHCR_USERNAME }}
-      ghcr_token: ${{ secrets.CHCR_TOKEN }}
+

--- a/.github/workflows/publish_to_ghcr.yml
+++ b/.github/workflows/publish_to_ghcr.yml
@@ -1,0 +1,69 @@
+name: Publish docker images
+
+on:
+  workflow_call:
+    inputs:
+      docker_context:
+        required: true
+        type: string
+      push_to_ghcr:
+        required: true
+        type: boolean
+      ghcr_repo:
+        required: false
+        default: false
+        type: string
+      image_tag:
+        required: false
+        default: ""
+        type: string
+    secrets:
+      ghcr_username:
+        required: false
+      ghcr_token:
+        required: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # 2.4.0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # v1.2.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25 # v1.6.0
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9 # v1.10.0
+        if: ${{ inputs.push_to_ghcr }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.ghcr_username }}
+          password: ${{ secrets.ghcr_token }}
+      - name: Construct tags string
+        id: tags
+        run: |
+          TAGS=""
+
+          if [ "${{ inputs.push_to_ghcr }}" == "true" ]; then
+
+            TAGS="${TAGS}${{ inputs.ghcr_repo }}:latest,"
+
+            if [ "${{ inputs.image_tag }}" != "" ]; then
+              TAGS="${TAGS}${{ inputs.ghcr_repo }}:${{ inputs.image_tag }},"
+            fi
+          fi
+
+          echo "::set-output name=tags::$TAGS"
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229 # v2.7.0
+        with:
+          context: ${{ inputs.docker_context }}
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}

--- a/.github/workflows/publish_to_ghcr.yml
+++ b/.github/workflows/publish_to_ghcr.yml
@@ -17,11 +17,7 @@ on:
         required: false
         default: ""
         type: string
-    secrets:
-      ghcr_username:
-        required: false
-      ghcr_token:
-        required: false
+
 
 permissions:
   contents: read
@@ -43,8 +39,8 @@ jobs:
         if: ${{ inputs.push_to_ghcr }}
         with:
           registry: ghcr.io
-          username: ${{ secrets.ghcr_username }}
-          password: ${{ secrets.ghcr_token }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Construct tags string
         id: tags
         run: |

--- a/aws-sam/Dockerfile
+++ b/aws-sam/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.10-alpine3.15
+
+RUN apk add --no-cache --virtual builddeps gcc musl-dev && \
+   pip --no-cache-dir install aws-sam-cli awscli && \
+   apk del builddeps
+
+RUN	adduser -s /bin/bash samcli \
+	--disabled-password \
+	&& echo 'samcli ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+
+USER samcli
+
+WORKDIR /home/samcli


### PR DESCRIPTION
Creates a docker file with the aws sam cli in
Added workflows to build and publish docker images to the ghcr.

This is basically the same pattern that's used in [tech-ops](https://github.com/alphagov/tech-ops). I didn't see any point in doing things differently right now, of course if this doesn't work for us, we can change how things are working.