### PR TITLE
PYI-571 - Build `gradle-sam` as an independent image

### DIFF
--- a/.github/workflows/build_aws_sam.yml
+++ b/.github/workflows/build_aws_sam.yml
@@ -6,6 +6,7 @@ on:
       - 'main'
     paths:
       - 'aws-sam/*'
+      - '.github/workflows/build_aws_sam.yml'
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/build_gradle_sam.yml
+++ b/.github/workflows/build_gradle_sam.yml
@@ -9,7 +9,7 @@ on:
       - '.github/workflows/build_gradle_sam.yml'
   registry_package:
     types:
-      - 'updated'
+      - 'published'
 
   workflow_dispatch:
     inputs:
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build-and-push:
-    if: github.event.registry_package.package.name == 'aws-sam'
+    if: github.event.type != package || github.event.registry_package.package.name == 'aws-sam'
     uses: alphagov/di-dockerfiles/.github/workflows/publish_to_ghcr.yml@main
     with:
       docker_context: ./gradle-sam

--- a/.github/workflows/build_gradle_sam.yml
+++ b/.github/workflows/build_gradle_sam.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build-and-push:
-    if: github.event.type != package || github.event.registry_package.package.name == 'aws-sam'
+    if: github.event.type != 'package' || github.event.registry_package.package.name == 'aws-sam'
     uses: alphagov/di-dockerfiles/.github/workflows/publish_to_ghcr.yml@main
     with:
       docker_context: ./gradle-sam

--- a/.github/workflows/build_gradle_sam.yml
+++ b/.github/workflows/build_gradle_sam.yml
@@ -1,0 +1,26 @@
+name: di-gradle-sam
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'aws-sam/*'
+      - 'gradle-sam/*'
+
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Tag used within docker repository to mark as unique"
+        required: false
+        type: string
+
+jobs:
+  build-and-push:
+    uses: alphagov/di-dockerfiles/.github/workflows/publish_to_ghcr.yml@main
+    with:
+      docker_context: ./gradle-sam
+      push_to_ghcr: true
+      ghcr_repo: ghcr.io/alphagov/gradle-sam
+      image_tag: ${{ github.event.inputs.image_tag }}
+

--- a/.github/workflows/build_gradle_sam.yml
+++ b/.github/workflows/build_gradle_sam.yml
@@ -5,8 +5,11 @@ on:
     branches:
       - 'main'
     paths:
-      - 'aws-sam/*'
       - 'gradle-sam/*'
+      - '.github/workflows/build_gradle_sam.yml'
+  registry_package:
+    types:
+      - 'updated'
 
   workflow_dispatch:
     inputs:
@@ -17,6 +20,7 @@ on:
 
 jobs:
   build-and-push:
+    if: github.event.registry_package.package.name == 'aws-sam'
     uses: alphagov/di-dockerfiles/.github/workflows/publish_to_ghcr.yml@main
     with:
       docker_context: ./gradle-sam

--- a/aws-sam/Dockerfile
+++ b/aws-sam/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10-alpine3.15
 
-RUN apk add --no-cache --virtual builddeps gcc musl-dev && \
-   pip --no-cache-dir install aws-sam-cli awscli && \
-   apk add jq --no-cache && \
-   apk del builddeps
+RUN apk add --no-cache --virtual builddeps gcc musl-dev \
+   && pip --no-cache-dir install aws-sam-cli awscli \
+   && apk add jq --no-cache \
+   && apk del builddeps

--- a/aws-sam/Dockerfile
+++ b/aws-sam/Dockerfile
@@ -2,26 +2,5 @@ FROM python:3.10-alpine3.15
 
 RUN apk add --no-cache --virtual builddeps gcc musl-dev && \
    pip --no-cache-dir install aws-sam-cli awscli && \
+   apk add jq --no-cache && \
    apk del builddeps
-
-RUN  apk update \
-  && apk upgrade \
-  && apk add --update openjdk11 tzdata curl unzip bash \
-  && rm -rf /var/cache/apk/*
-
-#install Gradle
-RUN wget -q https://services.gradle.org/distributions/gradle-7.3.3-bin.zip \
-    && unzip gradle-7.3.3-bin.zip -d /opt \
-    && rm gradle-7.3.3-bin.zip
-
-# Set Gradle in the environment variables
-ENV GRADLE_HOME /opt/gradle-7.3.3
-ENV PATH $PATH:/opt/gradle-7.3.3/bin
-
-RUN	adduser -s /bin/bash samcli \
-	--disabled-password \
-	&& echo 'samcli ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
-
-USER samcli
-
-WORKDIR /home/samcli

--- a/gradle-sam/Dockerfile
+++ b/gradle-sam/Dockerfile
@@ -1,0 +1,20 @@
+FROM ghcr.io/alphagov/aws-sam:latest
+
+# Install Java
+RUN apk update \
+  && apk upgrade \
+  && apk add --update openjdk11 tzdata curl unzip bash \
+  && rm -rf /var/cache/apk/*
+
+# Install Gradle
+ENV GRADLE_VERSION=7.3.3
+ARG GRADLE_BIN_SHA256=b586e04868a22fd817c8971330fec37e298f3242eb85c374181b12d637f80302
+
+RUN wget -q https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip \
+    && echo "${GRADLE_BIN_SHA256} *gradle-${GRADLE_VERSION}-bin.zip" | sha256sum -c - \
+    && unzip gradle-${GRADLE_VERSION}-bin.zip -d /opt \
+    && rm gradle-${GRADLE_VERSION}-bin.zip
+
+# Set Gradle in the environment variables
+ENV GRADLE_HOME /opt/gradle-${GRADLE_VERSION}
+ENV PATH $PATH:/opt/gradle-${GRADLE_VERSION}/bin


### PR DESCRIPTION
Removed gradle and java from the base `aws-sam` image
Added `jq` to the base `aws-sam` image
Created `gradle-sam` which uses `aws-sam` as a base
