### PR TITLE
fix registry_package trigger

### DIFF
--- a/.github/workflows/build_gradle_sam.yml
+++ b/.github/workflows/build_gradle_sam.yml
@@ -9,7 +9,7 @@ on:
       - '.github/workflows/build_gradle_sam.yml'
   registry_package:
     types:
-      - 'published'
+      - 'updated'
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
the docs don't make this clear but the workflow wasn't triggering on `published` so let's try `updated`.

in other words, @TomTucka was right and i was wrong 😄 