### PR TITLE
BAU: Add git-jq image

### DIFF
--- a/.github/workflows/build_git_jq.yml
+++ b/.github/workflows/build_git_jq.yml
@@ -1,0 +1,29 @@
+name: di-git-jq
+
+on:
+  push:
+    branches:
+      - 'bau-add-git-jq'
+    paths:
+      - 'git-jq/*'
+      - '.github/workflows/build_git_jq.yml'
+
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Tag used within docker repository to mark as unique"
+        required: false
+        type: string
+
+jobs:
+  build-and-push:
+    uses: alphagov/di-dockerfiles/.github/workflows/publish_to_ghcr.yml@main
+    permissions:
+      contents: read
+      packages: write
+    with:
+      docker_context: ./git-jq
+      push_to_ghcr: true
+      ghcr_repo: ghcr.io/alphagov/git-jq
+      image_tag: ${{ github.event.inputs.image_tag }}
+

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# Jetbrains
+.idea

--- a/git-jq/Dockerfile
+++ b/git-jq/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine/git:v2.32.0
+
+ENV PACKAGES "jq"
+
+RUN apk add $PACKAGES --no-cache


### PR DESCRIPTION
A lightweight image containing git and jq. Useful for Concourse
pipelines for displaying the changes that have caused a pipeline job to
be kicked off.